### PR TITLE
Fix favicon and OpenGraph image URLs

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -17,7 +17,7 @@ const { title, navigation, ogImagePath } = Object.assign(
 const fullTitle = title ? `${title}—PyCon AU 2025` : "PyCon AU 2025"
 
 const ogAbsoluteUrl = new URL(
-  ogImagePath ?? (og as any as string),
+  ogImagePath ?? og.src,
   "https://2025.pycon.org.au/",
 )
 ---

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import "./base.scss"
 import og from "../imgs/og.png"
+import favicon from "../imgs/favicon.ico"
 import Navigation from "../components/Navigation.astro"
 import Footer from "../components/Footer.astro"
 export type Props = {
@@ -35,7 +36,7 @@ const ogAbsoluteUrl = new URL(
       rel="icon"
       type="image/png"
       sizes="16x16"
-      href="/static/common/img/icons/favicon.ico"
+      href={favicon}
     />
     <script>
       // Record where the visitor came from.


### PR DESCRIPTION
This PR corrects the favicon and OpenGraph image URLs, which were previously pointing to `/static/common/img/icons/favicon.ico` (404) and `https://2025.pycon.org.au/[object%20Object]` respectively.