### PR TITLE
Note CFP close and hide program from nav

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -30,7 +30,7 @@ const { navClass, logo } = Object.assign(
   <ul>
     <li><a href="/about">About</a></li>
     <li><a href="/sponsor">Sponsor</a></li>
-    <li><a href="/program">Program</a></li>
+    <!-- <li><a href="/program">Program</a></li> -->
     <li><a href="/attend">Attend</a></li>
     <li><a href="/safety">Safety</a></li>
   </ul>

--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -9,10 +9,6 @@ import MailingListSignup from "../../components/MailingListSignup.astro"
 
 In 2025, PyCon AU will be held from **Friday the 12th to Tuesday the 16th of September** at **Pullman Melbourne On The Park** in Narrm/Melbourne.
 
-## Our Call for Proposals is open!
-
-**Want to present at PyCon AU?** Our call for proposals has been extended by 1 week, and is now open until Sunday the 22nd of June, 2025. See our <a href="/program">program</a> page for full details.
-
 ## Tickets now on sale!
 
 See our [attend page](/attend) for details.
@@ -24,6 +20,9 @@ Go to our [volunteer page](/attend/volunteer/) for more information.
 ## Sponsors
 
 We are always looking for [sponsors](/sponsor) to help us make the conference accessible and affordable!
+
+## Conference Schedule (soon)!
+Thank you to everyone who submitted a <a href="/program">proposal</a> for PyCon AU 2025! The CFP is now closed. We are currently reviewing all proposals and will announce the conference program in the coming weeks.
 
 ## Announcements
 

--- a/src/content/pages/program.mdx
+++ b/src/content/pages/program.mdx
@@ -6,6 +6,8 @@ import Button from "../../components/Button.astro"
 
 # PyCon AU call for proposals
 
+_Thank you to everyone who submitted to speak at PyCon AU 2025. The CFP is now closed, and we are reviewing all talk proposals. We aim to contact all submissions (successful or otherwise) by the end of July._
+
 We’d love you to present at PyCon AU 2025!
 
 **Our call for proposals has been extended by one week, and open until Sunday the 22nd June, 2025.**
@@ -19,7 +21,7 @@ You can submit your proposal through our online portal, Pretalx:
 <p>
   <center>
     <Button type="chonk" block href="https://pretalx.com/pycon-au-2025/cfp">
-      Submit to the PyCon AU CFP!
+      View your CFP submissions in Pretalx
     </Button>
   </center>
 </p>


### PR DESCRIPTION
I've retained the /program copy for historical references, and noted to speakers that we aim to contact them by the end of July.