### PR TITLE
Facilitate rich snippet display in Google search

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,6 +31,7 @@ const { Content, headings } = await entry.render()
         },
         "url": "https://2025.pycon.org.au/",
         "name": "PyCon AU 2025",
+        "description": "PyCon AU is Australia’s peak Python conference.",
         "image": conferenceImage.src,
         "startDate": "2025-09-12",
         "endDate": "2025-09-16",


### PR DESCRIPTION
This PR modifies the Schema.org metadata attached to the front page in order for Google to successfully extract information about the event.

Specifically:
* While `ExhibitionEvent` is correct and more specific, Google only supports `Event`.
* Event `address` and `eventAttendanceMode` clarified.
* Description, image and ticket purchasing link added.

Docs: https://developers.google.com/search/docs/appearance/structured-data/event
Testing: https://search.google.com/test/rich-results