### PR TITLE
Remove useless trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  # TODO: make this workflow run conditional on a commit actually being created
-  workflow_run:
-    workflows: [Update schedule]
-    types: [completed]
 
 permissions:
   contents: read


### PR DESCRIPTION
This workflow will be run by the push/branches/main trigger if the update schedule job commits anything