### PR TITLE
Add horizontal line to indicate current time in program

### DIFF
--- a/src/pages/program/[day].astro
+++ b/src/pages/program/[day].astro
@@ -406,6 +406,42 @@ const tracksByRoom = Object.fromEntries(
           ),
         )
       }
+      <s-now-rule style={`display: none; min-height: 0.25rem;`}></s-now-rule>
     </s-schedule>
+    <script>
+      function refreshNowRule() {
+        const scheduleContainer = document.querySelector(
+          "s-schedule",
+        )! as HTMLElement
+
+        const nowRuleElement = document.querySelector(
+          "s-now-rule",
+        )! as HTMLElement
+
+        const time = Date.now()
+        const timeIdx = Math.floor(time / (5 * 60 * 1000))
+
+        const dayStart = parseInt(
+          scheduleContainer.style.getPropertyValue("--day-start"),
+        )
+        const dayEnd = parseInt(
+          scheduleContainer.style.getPropertyValue("--day-end"),
+        )
+
+        if (timeIdx > dayStart && timeIdx < dayEnd) {
+          nowRuleElement.style.setProperty("display", "block")
+          nowRuleElement.style.setProperty("--at", timeIdx.toString())
+        } else {
+          nowRuleElement.style.setProperty("display", "none")
+        }
+
+        setTimeout(
+          refreshNowRule,
+          60000, // one minute
+        )
+      }
+
+      setTimeout(refreshNowRule, 0)
+    </script>
   </s-schedule-outer>
 </Base>


### PR DESCRIPTION
This PR adds a red horizontal line to indicate the current time on the conference program. The CSS for this, and in fact this feature was added in 2021, however the site redesign in 2023 removed the relevant JavaScript. This PR reimplements the code.

**Test plan:** I have confirmed that this shows the correct time, does not appear on any program page for a day which it isn't, and works correctly on smaller devices.

**Screenshot:**

<img width="271" height="183" alt="Screenshot 2025-09-13 at 3 51 49 pm" src="https://github.com/user-attachments/assets/391b6fb1-8907-4a83-82c5-a5263164992e" />